### PR TITLE
Fix vanniktech maven publish plugin 0.34.0 compatibility and javadoc errors

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,15 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(find:*)",
+      "Bash(git add:*)",
+      "Bash(git commit:*)",
+      "Bash(git push:*)",
+      "Bash(git checkout:*)",
+      "mcp__zen__thinkdeep",
+      "Bash(./gradlew:*)",
+      "mcp__zen__codereview"
+    ],
+    "deny": []
+  }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,6 @@ plugins {
     id 'net.researchgate.release' version '3.1.0'
 }
 
-import com.vanniktech.maven.publish.SonatypeHost
 import com.vanniktech.maven.publish.JavaLibrary
 import com.vanniktech.maven.publish.JavadocJar
 
@@ -101,7 +100,7 @@ tasks.test {
 // Maven Central Publishing Tasks
 mavenPublishing {
   configure(new JavaLibrary(new JavadocJar.Javadoc(), true))
-  publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)
+  // publishToMavenCentral() is now configured via gradle.properties
   signAllPublications()
   coordinates("com.digitalsanctuary", "ds-spring-ai-client", project.version)
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,5 @@
 version=1.1.5-SNAPSHOT
+
+# Maven Central Publishing Configuration for vanniktech plugin 0.34.0+
+mavenCentralPublishing=true
+mavenCentralAutomaticPublishing=true

--- a/src/main/java/com/digitalsanctuary/springaiclient/adapters/AbstractAIService.java
+++ b/src/main/java/com/digitalsanctuary/springaiclient/adapters/AbstractAIService.java
@@ -18,7 +18,6 @@ package com.digitalsanctuary.springaiclient.adapters;
  * <ul>
  *   <li>OpenAIService - For interacting with OpenAI's models</li>
  * </ul>
- * </p>
  * <p>
  * Future implementations may include:
  * <ul>
@@ -26,7 +25,6 @@ package com.digitalsanctuary.springaiclient.adapters;
  *   <li>GeminiService - For Google's Gemini models</li>
  *   <li>MistralService - For Mistral AI models</li>
  * </ul>
- * </p>
  *
  * @see com.digitalsanctuary.springaiclient.adapters.openai.service.OpenAIService
  */

--- a/src/main/java/com/digitalsanctuary/springaiclient/adapters/openai/config/OpenAIConfigProperties.java
+++ b/src/main/java/com/digitalsanctuary/springaiclient/adapters/openai/config/OpenAIConfigProperties.java
@@ -35,7 +35,6 @@ import lombok.Data;
  *   <li>output-tokens: Maximum tokens in responses (defaults to 4096)</li>
  *   <li>system-prompt: Default system prompt (defaults to "You are a helpful assistant.")</li>
  * </ul>
- * </p>
  * <p>
  * For security, it's recommended to use environment variables for sensitive properties
  * like api-key rather than hardcoding them in configuration files.

--- a/src/main/java/com/digitalsanctuary/springaiclient/adapters/openai/dto/OpenAIRequest.java
+++ b/src/main/java/com/digitalsanctuary/springaiclient/adapters/openai/dto/OpenAIRequest.java
@@ -27,7 +27,6 @@ import lombok.Data;
  *     .build();
  * }
  * </pre>
- * </p>
  * <p>
  * The request is serialized to JSON when sent to the OpenAI API. The JSON structure
  * follows OpenAI's API specification for chat completions.

--- a/src/main/java/com/digitalsanctuary/springaiclient/adapters/openai/dto/Usage.java
+++ b/src/main/java/com/digitalsanctuary/springaiclient/adapters/openai/dto/Usage.java
@@ -22,7 +22,6 @@ import lombok.Data;
  *   <li>Completion tokens - Tokens generated in the API response</li>
  *   <li>Total tokens - Sum of prompt and completion tokens</li>
  * </ul>
- * </p>
  * <p>
  * Example usage:
  * <pre>
@@ -32,7 +31,6 @@ import lombok.Data;
  * System.out.println("Total tokens used: " + usage.getTotalTokens());
  * }
  * </pre>
- * </p>
  */
 @Data
 public class Usage {

--- a/src/main/java/com/digitalsanctuary/springaiclient/adapters/openai/service/OpenAIService.java
+++ b/src/main/java/com/digitalsanctuary/springaiclient/adapters/openai/service/OpenAIService.java
@@ -38,7 +38,6 @@ import lombok.extern.slf4j.Slf4j;
  * OpenAIResponse response = openAIService.sendRequest(request);
  * }
  * </pre>
- * </p>
  */
 @Slf4j
 @Service
@@ -81,7 +80,6 @@ public class OpenAIService extends AbstractAIService {
      *     .build();
      * }
      * </pre>
-     * </p>
      *
      * @return a new RequestBuilder object with default configuration values
      * @see RequestBuilder
@@ -107,7 +105,6 @@ public class OpenAIService extends AbstractAIService {
      * String answer = response.getMessage();
      * }
      * </pre>
-     * </p>
      *
      * @param text the user message to send to the AI
      * @return the response from OpenAI containing the generated message and usage information


### PR DESCRIPTION
## Summary
- Fixed compatibility issues with vanniktech maven publish plugin version 0.34.0
- Fixed javadoc HTML errors that were preventing successful builds

## Changes

### Vanniktech Plugin 0.34.0 Compatibility
- Removed deprecated `SonatypeHost` import that was removed in 0.34.0
- Removed explicit `publishToMavenCentral()` call (now auto-configured via properties)
- Added `mavenCentralPublishing=true` and `mavenCentralAutomaticPublishing=true` to gradle.properties

### Javadoc Fixes
- Fixed malformed HTML in javadoc comments (orphaned `</p>` tags after `<ul>` and `<pre>` blocks)
- Fixed javadoc in: AbstractAIService, OpenAIConfigProperties, OpenAIRequest, Usage, and OpenAIService

## Test plan
- [x] Verified `./gradlew clean build` works successfully
- [x] Verified `./gradlew publishToMavenLocal` works without errors
- [x] All tests pass with both JDK 17 and 21

🤖 Generated with [Claude Code](https://claude.ai/code)